### PR TITLE
revise README.md with markdownlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 ![demo](https://github.com/ShinobuAmasaki/fpm-completions/assets/100006043/635de99f-e562-4d86-b05c-92697fe075f0)
 
 # fpm-completions
+
 Command-line completion functions for the Fortran Package Manager.
 
 ## Bash
+
 This package provides a completion script for bash.
 
 To use the script `bash/fpm.bash`, Bash (v4.x, or newer) and bash-completion

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Command-line completion functions for the Fortran Package Manager.
 ## Bash
 This package provides a completion script for bash.
 
-To use the script `bash/fpm.bash`, Bash (v4.x, or newer) and bash-completion(v2.x, or newer) are required.
+To use the script `bash/fpm.bash`, Bash (v4.x, or newer) and bash-completion
+(v2.x, or newer) are required.
 
-Put the `fpm.bash` file in the `bash/` directory into the directory `~/.local/share/bash-completion/completions`.
+Put the `fpm.bash` file in the `bash/` directory into the directory
+`~/.local/share/bash-completion/completions`.
 
 Then, reload the shell.
 ```shell
@@ -19,7 +21,8 @@ $ exec -l $SHELL
 
 This package also provides a completion script for Zsh.
 
-Put the `_fpm` file in the `zsh/` directory into the directory described in the shell variable `fpath`.
+Put the `_fpm` file in the `zsh/` directory into the directory described in the
+shell variable `fpath`.
 
 Furthermore, add the following to `~/.zshrc`:
 ```shell
@@ -32,7 +35,8 @@ Finally, reload the shell.
 % exec -l $SHELL
 ```
 
-For example, if you place the `_fpm` file in `~/zsh/functions`, the `~/.zshrc` will be like this:
+For example, if you place the `_fpm` file in `~/zsh/functions`, the `~/.zshrc`
+will be like this:
 
 ```shell
 fpath=( "$HOME/zsh/functions" "${fpath[@]}" )

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ To use the script `bash/fpm.bash`, Bash (v4.x, or newer) and bash-completion
 Put the `fpm.bash` file in the `bash/` directory into the directory
 `~/.local/share/bash-completion/completions`.
 
-Then, reload the shell.
+Then, reload the shell:
+
 ```shell
 $ exec -l $SHELL
 ```
@@ -27,12 +28,14 @@ Put the `_fpm` file in the `zsh/` directory into the directory described in the
 shell variable `fpath`.
 
 Furthermore, add the following to `~/.zshrc`:
+
 ```shell
 autoload -Uz compinit
 compinit -u
 ```
 
 Finally, reload the shell.
+
 ```shell
 % exec -l $SHELL
 ```
@@ -47,6 +50,7 @@ compinit -u
 ```
 
 Don't forget to reload the shell.
+
 ```shell
 % exec -l $SHELL
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Command-line completion functions for the Fortran Package Manager.
 
 ## Bash
-This package provides a completion script for bash. 
+This package provides a completion script for bash.
 
 To use the script `bash/fpm.bash`, Bash (v4.x, or newer) and bash-completion(v2.x, or newer) are required.
 
@@ -40,7 +40,7 @@ autoload -Uz compinit
 compinit -u
 ```
 
-Don't forget to reload the shell. 
+Don't forget to reload the shell.
 ```shell
 % exec -l $SHELL
 ```


### PR DESCRIPTION
File `README.md` was revised following the suggestions by [markdownlint](https://github.com/markdownlint/markdownlint) (version 0.13.0 as packaged for Debian 13/trixie, [package tracker](https://tracker.debian.org/pkg/ruby-mdl)).

In the version eventually obtained, `markdownlint` still identifies line 19 as a potential issue and reports

```
MD014 Dollar signs used before commands without showing output
```

It is intentionally left untouched because the syntax checker describes reasons where beginning a line with a `$` can be reasonable (cf. `RULES.md`, or [here](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md))