### PR TITLE
Add bash completion for fpm response file: fpm.rsp

### DIFF
--- a/bash/fpm.bash
+++ b/bash/fpm.bash
@@ -159,7 +159,12 @@ _fpm() {
 
    case $cword in
       1)
-         COMPREPLY=( $(compgen -W 'build clean help install list new publish run test' -- "$cur") )
+		 if [[ "$prev" == "fpm" && "$cur" == "@"* ]]; then
+			commands=$(grep "^@" ./fpm.rsp 2>/dev/null | cut -c 1-)
+			COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+		 else
+         	COMPREPLY=( $(compgen -W 'build clean help install list new publish run test' -- "$cur") )
+		 fi
          ;;
       *)
          case ${words[1]} in


### PR DESCRIPTION
Hi,

This PR references issue #4.

Here is an example of what I used for an `fpm.rsp` file: https://github.com/gha3mi/forbenchmark/blob/main/fpm.rsp.

Theoretically, you define your commands with `@command` followed by fpm options in the `fpm.rsp` file located in the same path as the `fpm.toml` file.

For more information, you can find it by running `fpm --help` or visiting https://urbanjost.github.io/M_CLI2/set_args.3m_cli2.html.

Thanks,
Ali